### PR TITLE
fix(client): Remove float right from roundButton class - PST-102

### DIFF
--- a/client/src/components/RoundButton.vue
+++ b/client/src/components/RoundButton.vue
@@ -65,7 +65,6 @@ export default defineComponent({
 }
 
 .roundButton {
-    float: right;
     background-color: black;
     border: none;
     cursor: pointer;


### PR DESCRIPTION
In [production](https://duckduckpatent.com) there was a weird [bug](https://tpro.atlassian.net/jira/software/projects/PST/boards/2?selectedIssue=PST-102) when going to the saved page and then back.

Somehow this was caused by 'float: right' being set on the round button. The fix is deployed and seems to work
