### PR TITLE
Add family nodes / links to main visualization - PST-120

### DIFF
--- a/client/src/components/OptionsMenu.vue
+++ b/client/src/components/OptionsMenu.vue
@@ -25,22 +25,27 @@
                 <ToggleSwitch
                     :default-state="isPatentsOn"
                     custom-color="#a88529"
-                    v-on:on-clicked="onClicked($event, nodes[0].type)"
+                    v-on:on-clicked="onClicked($event, 'patents')"
+                ></ToggleSwitch>
+                <ToggleSwitch
+                    :default-state="isFamiliesOn"
+                    custom-color="#ddb906"
+                    v-on:on-clicked="onClicked($event, 'families')"
                 ></ToggleSwitch>
                 <ToggleSwitch
                     :default-state="isAuthorsOn"
                     custom-color="#A82929"
-                    v-on:on-clicked="onClicked($event, nodes[1].type)"
+                    v-on:on-clicked="onClicked($event, 'authors')"
                 ></ToggleSwitch>
                 <ToggleSwitch
                     :default-state="isCompaniesOn"
                     custom-color="#2973A8"
-                    v-on:on-clicked="onClicked($event, nodes[2].type)"
+                    v-on:on-clicked="onClicked($event, 'companies')"
                 ></ToggleSwitch>
                 <ToggleSwitch
                     :default-state="isCitationsOn"
                     custom-color="#487909"
-                    v-on:on-clicked="onClicked($event, nodes[3].type)"
+                    v-on:on-clicked="onClicked($event, 'citations')"
                 ></ToggleSwitch>
             </div>
         </div>
@@ -89,6 +94,9 @@ export default defineComponent({
     computed: {
         isPatentsOn(): boolean {
             return this.$props.options.includes('patents');
+        },
+        isFamiliesOn(): boolean {
+            return this.$props.options.includes('families');
         },
         isAuthorsOn(): boolean {
             return this.$props.options.includes('authors');

--- a/client/src/components/OptionsMenu.vue
+++ b/client/src/components/OptionsMenu.vue
@@ -29,7 +29,7 @@
                 ></ToggleSwitch>
                 <ToggleSwitch
                     :default-state="isFamiliesOn"
-                    custom-color="#ddb906"
+                    custom-color="#896978"
                     v-on:on-clicked="onClicked($event, 'families')"
                 ></ToggleSwitch>
                 <ToggleSwitch

--- a/client/src/components/OptionsMenu.vue
+++ b/client/src/components/OptionsMenu.vue
@@ -76,7 +76,13 @@ export default defineComponent({
         return {
             openMenu: false,
             timer: 0,
-            nodes: [{ type: 'patents' }, { type: 'authors' }, { type: 'companies' }, { type: 'citations' }],
+            nodes: [
+                { type: 'patents' },
+                { type: 'families' },
+                { type: 'authors' },
+                { type: 'companies' },
+                { type: 'citations' },
+            ],
         };
     },
     props: {

--- a/client/src/components/ResultVisualization.vue
+++ b/client/src/components/ResultVisualization.vue
@@ -759,7 +759,7 @@ circle.citation {
 }
 
 circle.family {
-    fill: $yellow;
+    fill: $purple;
     stroke: none;
 }
 

--- a/client/src/components/ResultVisualization.vue
+++ b/client/src/components/ResultVisualization.vue
@@ -331,6 +331,7 @@ export default defineComponent({
         updateData(): void {
             const patents = this.patents as Patent[];
             const citationMap = VisualizationHelperService.getCitationMap(patents);
+            const familyMap = VisualizationHelperService.getFamilyMap(patents);
 
             let authorsMap = {} as RelationMap;
             if (this.visualizationOptions.includes('authors')) {
@@ -345,6 +346,7 @@ export default defineComponent({
             const nextNodes = VisualizationHelperService.getNodes(
                 patents,
                 citationMap,
+                familyMap,
                 this.visualizationOptions as string[],
                 this.selectedNode,
                 authorsMap,
@@ -356,6 +358,7 @@ export default defineComponent({
             this.graph.links = VisualizationHelperService.getLinks(
                 this.graph.nodes,
                 citationMap,
+                familyMap,
                 authorsMap,
                 companyMap,
             );
@@ -698,6 +701,8 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
+@import '../styles/colors';
+
 .d3-container {
     width: 100vw;
     height: 100vh;
@@ -744,22 +749,27 @@ circle {
 }
 
 circle.patent {
-    fill: rgb(168, 133, 41);
+    fill: $brown;
     stroke: none;
 }
 
 circle.citation {
-    fill: green;
+    fill: $green;
+    stroke: none;
+}
+
+circle.family {
+    fill: $yellow;
     stroke: none;
 }
 
 circle.author {
-    fill: brown;
+    fill: $red;
     stroke: none;
 }
 
 circle.company {
-    fill: rgb(41, 115, 168);
+    fill: $blue;
     stroke: none;
 }
 

--- a/client/src/models/VisualPatentNode.ts
+++ b/client/src/models/VisualPatentNode.ts
@@ -4,7 +4,6 @@ import { Patent } from '@/models/Patent';
 export interface VisualPatentNode extends SimulationNodeDatum {
     id: string;
     patent: Patent;
-    type: 'patent' | 'author' | 'citation' | 'company';
-    color: string;
+    type: 'patent' | 'author' | 'citation' | 'company' | 'family';
     size: number;
 }

--- a/client/src/services/visualization-helper.service.ts
+++ b/client/src/services/visualization-helper.service.ts
@@ -90,19 +90,20 @@ export default class VisualizationHelperService {
 
             nodes = [...nodes, ...citationNodes]; // Extend the nodes array with the citation nodes
         }
-
-        const familyNodes = Object.keys(familyMap)
-            .filter((t) => familyMap[t].length > 1)
-            .map((id) => {
-                const patentsInFamily = familyMap[id];
-                return {
-                    id, // Set the id to be the family Id
-                    patent: patentMap[patentsInFamily[0]], // used for tooltip ect. - this should change
-                    type: 'family', // Set the type of the node to 'family'
-                    size: patentsInFamily.length * 3 + 5, // Use dynamic sizing to show relative importance
-                } as VisualPatentNode;
-            });
-        nodes = [...nodes, ...familyNodes];
+        if (vizOptions.includes('families')) {
+            const familyNodes = Object.keys(familyMap)
+                .filter((t) => familyMap[t].length > 1)
+                .map((id) => {
+                    const patentsInFamily = familyMap[id];
+                    return {
+                        id, // Set the id to be the family Id
+                        patent: patentMap[patentsInFamily[0]], // used for tooltip ect. - this should change
+                        type: 'family', // Set the type of the node to 'family'
+                        size: patentsInFamily.length * 3 + 5, // Use dynamic sizing to show relative importance
+                    } as VisualPatentNode;
+                });
+            nodes = [...nodes, ...familyNodes];
+        }
 
         return nodes;
     }

--- a/client/src/services/visualization-helper.service.ts
+++ b/client/src/services/visualization-helper.service.ts
@@ -54,7 +54,6 @@ export default class VisualizationHelperService {
             nodes = [...nodes, ...companyNodes];
         }
 
-
         // If the user has selected to view citations
         if (vizOptions.includes('citations')) {
             const citationNodes = Object.keys(citationMap) // Get the keys (citation ids) from the citationMap.

--- a/client/src/store/SavedAppState.ts
+++ b/client/src/store/SavedAppState.ts
@@ -19,7 +19,7 @@ export class SavedAppState {
     /**
      * Node visualization options
      */
-    public visualizationOptions = ['patents'];
+    public visualizationOptions = ['patents', 'families'];
 
     /**
      * Contains the saved patents

--- a/client/src/styles/colors.scss
+++ b/client/src/styles/colors.scss
@@ -1,0 +1,6 @@
+
+$red: rgb(168, 41, 41);
+$blue: rgb(41, 115, 168);
+$brown: rgb(168, 133, 41);
+$green: rgb(72, 121, 9);
+$yellow: #ddb906;

--- a/client/src/styles/colors.scss
+++ b/client/src/styles/colors.scss
@@ -1,6 +1,6 @@
 
-$red: rgb(168, 41, 41);
-$blue: rgb(41, 115, 168);
-$brown: rgb(168, 133, 41);
-$green: rgb(72, 121, 9);
+$red: #A82929;
+$blue: #2973A8;
+$brown: #a88529;
+$green: #487909;
 $yellow: #ddb906;

--- a/client/src/styles/colors.scss
+++ b/client/src/styles/colors.scss
@@ -3,4 +3,4 @@ $red: #A82929;
 $blue: #2973A8;
 $brown: #a88529;
 $green: #487909;
-$yellow: #ddb906;
+$purple: #896978;

--- a/client/src/styles/global.scss
+++ b/client/src/styles/global.scss
@@ -12,6 +12,8 @@
     --primary-color: #00000;
 }
 
+
+
 .no-select {
     -webkit-user-select: none;
     user-select: none;


### PR DESCRIPTION
This one will require some group feedback. There aren't that many family ties being brought back in the average search, so It's not clear if this will be that important.

If it's desired we can skip the family nodes and just directly connect patents in the same family, but personally I think the family nodes are nice.

I've found including the term 'family' tends to lead to some families being shown in the results, but I'm sure there's lots of better terms out there.