### PR TITLE
feat(client): Show author/company information - PST-154

### DIFF
--- a/client/src/components/NodePreview.vue
+++ b/client/src/components/NodePreview.vue
@@ -15,6 +15,7 @@
                 <div class="node-preview-subtitle">{{ current.subTitle }}</div>
             </div>
         </template>
+        <!--            Previewing the Patent title and the patent number-->
         <div class="node-preview-body">
             <div
                 v-for="rel in current.relatedPatents"
@@ -69,6 +70,7 @@ export default defineComponent({
             this.$emit('onControlChange', { direction: 'next' });
             this.showOptionsMenu = false;
         },
+
         /**
          * Method to check if back button is clicked then emit an event to ask the parent to send previous patent
          */
@@ -106,6 +108,21 @@ export default defineComponent({
     border-radius: 10px;
     padding: 0 10px;
 }
+
+.node-preview-title.author {
+    color: white;
+    background-color: $red;
+    border-radius: 10px;
+    padding: 0 10px;
+}
+
+.node-preview-title.company {
+    color: white;
+    background-color: $blue;
+    border-radius: 10px;
+    padding: 0 10px;
+}
+
 .node-preview-body {
     text-align: left;
     font-style: normal;
@@ -133,7 +150,6 @@ export default defineComponent({
     position: absolute;
     bottom: 32px;
     right: 32px;
-
     display: flex;
     gap: 12px;
 

--- a/client/src/components/ResultVisualization.vue
+++ b/client/src/components/ResultVisualization.vue
@@ -129,9 +129,9 @@ export default defineComponent({
                 case 'patent':
                     return this.currentNode?.patent.title;
                 case 'author':
-                    return this.currentNode?.id;
+                    return `AUT: ${this.currentNode?.id}`;
                 case 'company':
-                    return this.currentNode?.id;
+                    return `CO.: ${this.currentNode?.id}`;
                 case 'citation':
                     return `CITATION: ${this.currentNode?.id}`;
                 case 'family':

--- a/client/src/services/preview-helper.service.ts
+++ b/client/src/services/preview-helper.service.ts
@@ -57,7 +57,7 @@ export default class PreviewHelperService {
             id: node.id,
             title: `${node.id}`,
             type: node.type,
-            subTitle: 'Inventor of',
+            subTitle: 'Author of',
             relatedPatents: authorPatents,
         };
     }

--- a/client/src/services/preview-helper.service.ts
+++ b/client/src/services/preview-helper.service.ts
@@ -5,6 +5,11 @@ import { PatentPreview } from '@/models/PatentPreview';
 import { NodePreview } from '@/models/NodePreview';
 
 export default class PreviewHelperService {
+    /**
+     * Helper to get the title, abstract for the patent preview on cliking on the node
+     * @param patent
+     * @param savedPatents
+     */
     static getPatentPreview(patent: Patent, savedPatents: PatentMap): PatentPreview {
         let author = (patent?.applicants ?? [])[0] ?? '';
         if (patent?.applicants?.length ?? 0 > 1) {
@@ -23,6 +28,12 @@ export default class PreviewHelperService {
         };
     }
 
+    /**
+     * Helper to get the citation number and related patent for node preview
+     * @param node
+     * @param patents
+     */
+
     static getCitationPreview(node: NodeInfo, patents: Patent[]): NodePreview {
         const citedPatents = patents.filter((t) => t?.citations?.some((t) => t.id === node?.id));
         return {
@@ -31,6 +42,39 @@ export default class PreviewHelperService {
             type: node.type,
             subTitle: 'Cited By',
             relatedPatents: citedPatents,
+        };
+    }
+
+    /**
+     * Helper to get the author name and the invented patents for node preview
+     * @param node
+     * @param patents
+     */
+
+    static getAuthorPreview(node: NodeInfo, patents: Patent[]): NodePreview {
+        const authorPatents = patents.filter((patent) => patent.inventors?.includes(node.id));
+        return {
+            id: node.id,
+            title: `${node.id}`,
+            type: node.type,
+            subTitle: 'Inventor of',
+            relatedPatents: authorPatents,
+        };
+    }
+
+    /**
+     * Helper to get the company name and current assignee to the patents
+     * @param node
+     * @param patents
+     */
+    static getCompanyPreview(node: NodeInfo, patents: Patent[]): NodePreview {
+        const companyPatents = patents.filter((patent) => patent.applicants?.includes(node.id));
+        return {
+            id: node.id,
+            title: `${node.id}`,
+            type: node.type,
+            subTitle: 'Applicant of',
+            relatedPatents: companyPatents,
         };
     }
 }

--- a/client/src/views/Results.vue
+++ b/client/src/views/Results.vue
@@ -551,12 +551,9 @@ export default defineComponent({
         navigationNodes(e: { direction: string }, collection: string[], indexNode: number, type: NodeType) {
             switch (e.direction) {
                 case 'next':
-                    console.log('i am pushing the next', indexNode);
-                    console.log('i am pushing length the next', collection.length);
                     indexNode = (indexNode + 1) % collection.length;
                     break;
                 case 'previous':
-                    console.log('i am pushing the back', indexNode);
                     indexNode = indexNode - 1;
                     indexNode = indexNode < 0 ? collection.length - 1 : indexNode;
                     break;


### PR DESCRIPTION
In order to keep the consistency of our design, the design of the author and company preview has the same style as @micahh2 implemented. On clicking on the author node should the author and related patent shown and on the company node the company name and related patent shown. The arrow functionality was redefined in order to feat to all previews. Depending on the type of node the arrow adopts the behaviour.