### PR TITLE
Refine filters - PST-122, PST-138

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
                 "vue-highlightable-input": "^1.0.9",
                 "vue-router": "^4.0.11",
                 "vue-window-size": "^1.1.2",
+                "vue3-click-away": "^1.2.1",
                 "vuex": "^4.0.0-0"
             },
             "devDependencies": {
@@ -25817,6 +25818,11 @@
                 "vue": ">=3.0.0"
             }
         },
+        "node_modules/vue3-click-away": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/vue3-click-away/-/vue3-click-away-1.2.1.tgz",
+            "integrity": "sha512-8GA3rfFlwIS9oCqFzqGdk7CvUz7JwvoiBJQLW4BxrVQEgzTB9oo/lWMazz4XwouA8tnquIHa2ZBHLix689RpAg=="
+        },
         "node_modules/vuex": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
@@ -48260,6 +48266,11 @@
             "requires": {
                 "window-resize-subject": "^1.5.0"
             }
+        },
+        "vue3-click-away": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/vue3-click-away/-/vue3-click-away-1.2.1.tgz",
+            "integrity": "sha512-8GA3rfFlwIS9oCqFzqGdk7CvUz7JwvoiBJQLW4BxrVQEgzTB9oo/lWMazz4XwouA8tnquIHa2ZBHLix689RpAg=="
         },
         "vuex": {
             "version": "4.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
         "vue-highlightable-input": "^1.0.9",
         "vue-router": "^4.0.11",
         "vue-window-size": "^1.1.2",
+        "vue3-click-away": "^1.2.1",
         "vuex": "^4.0.0-0"
     },
     "devDependencies": {

--- a/client/src/components/Filter.vue
+++ b/client/src/components/Filter.vue
@@ -56,7 +56,7 @@ export default defineComponent({
     flex: 1;
     background-color: black;
     color: white;
-    text-align: center;
+    text-align: left; // selected options (in middle) look nicer when they don't change in spacing
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -76,6 +76,7 @@ export default defineComponent({
     border-right: none;
     background-color: white;
     color: black;
+    text-align: center; // filter names look nicer when centered
 }
 .filter > .tail {
     border: 1px solid black;

--- a/client/src/components/Filters.vue
+++ b/client/src/components/Filters.vue
@@ -11,7 +11,7 @@
                 <div
                     :class="{ invisible: filter.type !== 'date', 'year-selector-target': true, 'value-selector': true }"
                 >
-                    <div class="year-selector">
+                    <div class="year-selector" @mouseleave="updateFocus">
                         <div>
                             <label for="dateFrom">from</label>
                             <label for="dateTo">to</label>
@@ -53,6 +53,7 @@
                     :list="languageList"
                     v-on:select="onListItemSelected(filter, $event.key)"
                     v-on:scroll="updateFocus"
+                    @mouseleave="updateFocus"
                 />
             </div>
 
@@ -69,6 +70,7 @@
                     :list="countryList"
                     v-on:select="onListItemSelected(filter, $event.key)"
                     v-on:scroll="updateFocus"
+                    @mouseleave="updateFocus"
                 />
             </div>
         </div>
@@ -183,6 +185,8 @@ export default defineComponent({
             if (value == null) {
                 return;
             }
+            console.log('filters page, watch. new filter val: ', value);
+
             const filters = value as Filter[];
             this.hasDate = filters.some((t) => t.type === 'date');
             this.hasLanguage = filters.some((t) => t.type === 'language');
@@ -191,8 +195,12 @@ export default defineComponent({
 
             this.currentFilter = filters.find((t) => t.type === 'empty' || t.isSelectionOpen) ?? null;
             if (this.currentFilter == null) {
+                console.log('null found ');
                 return;
             }
+
+            console.log('filters .... current filter val: ', this.currentFilter);
+
             const yearParts = this.currentFilter.value.split('-');
             this.dateFilterFrom = `${yearParts[0] ?? ''}`;
             this.dateFilterTo = `${yearParts[1] ?? ''}`;
@@ -273,6 +281,7 @@ export default defineComponent({
         updateFocus() {
             // This timeout might be null
             if (this.focusTimeout != null) {
+                console.log('filters page, updateFocus.timeout not null. clearing..');
                 clearTimeout(this.focusTimeout); // Stop the scheduled timeout
             }
             this.focusTimeout = setTimeout(() => {
@@ -286,10 +295,12 @@ export default defineComponent({
          */
         onLostFocus() {
             if (this.currentFilter == null) {
+                console.log('filters page, lostFocus.currFilter null, user doesnt want to add anything.');
                 return;
             } // If there isn't a currently focused element then forget about it
             // Emit update that changes isSelectionOpen (edit mode) to false
             this.$emit('updateFilter', { prop: 'isSelectionOpen', value: false, id: this.currentFilter.id });
+            console.log('filters page, lostFocus.emit to close selection is sent.');
             // Set the current filter to null, it's no longer current
             this.currentFilter = null;
         },

--- a/client/src/components/Filters.vue
+++ b/client/src/components/Filters.vue
@@ -113,12 +113,14 @@
             </div>
         </div>
     </div>
-    <ChipButton
-        :class="{ invisible: currentFilter || hasAll, 'add-button': true }"
-        icon-key="add"
-        text="Add"
-        v-on:on-select="onAddClicked()"
-    ></ChipButton>
+    <div class="filter-bottom-controls">
+        <ChipButton
+            :class="{ invisible: currentFilter || hasAll, 'add-button': true }"
+            icon-key="add"
+            text="Add"
+            v-on:on-select="onAddClicked()"
+        ></ChipButton>
+    </div>
 </template>
 
 <script lang="ts">
@@ -395,21 +397,24 @@ export default defineComponent({
 
 .filter-container {
     margin-top: 10px;
+    margin-right: 5px;
+    margin-left: 5px;
 }
-
+.filter-bottom-controls {
+    margin-right: 5px;
+    margin-left: 5px;
+}
 .type-selection {
     display: flex;
     justify-content: space-between;
     min-height: 2em;
-}
-.type-selection > * {
 }
 
 .add-button {
     margin-top: 8px;
     float: right;
     width: 90px;
-    margin-right: 0 !important;
+    //  margin-right: 0 !important;
 }
 .invisible {
     visibility: hidden;

--- a/client/src/components/Filters.vue
+++ b/client/src/components/Filters.vue
@@ -409,6 +409,7 @@ export default defineComponent({
     margin-top: 8px;
     float: right;
     width: 90px;
+    margin-right: 0 !important;
 }
 .invisible {
     visibility: hidden;

--- a/client/src/components/Filters.vue
+++ b/client/src/components/Filters.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-for="filter in filters" :key="filter.id" class="filter-container">
-        <div v-if="filter.type === 'date' && (filter.value.length > 7 || filter.isSelectionOpen)">
+        <div v-if="eligible(filter, 'date')">
             <FilterComponent
                 name="date"
                 :value="filter.value"
@@ -9,7 +9,7 @@
                 v-on:delete="onRemoveClicked(filter.id)"
             />
         </div>
-        <div v-if="filter.type === 'language' && (filter.value !== '' || filter.isSelectionOpen)">
+        <div v-if="eligible(filter, 'language')">
             <FilterComponent
                 name="language"
                 :value="displayValue(languageList, filter.value)"
@@ -18,7 +18,7 @@
                 v-on:delete="onRemoveClicked(filter.id)"
             />
         </div>
-        <div v-if="filter.type === 'country' && (filter.value !== '' || filter.isSelectionOpen)">
+        <div v-if="eligible(filter, 'country')">
             <FilterComponent
                 name="country"
                 :value="displayValue(countryList, filter.value)"
@@ -55,7 +55,6 @@
                                 :value="dateFilterFrom"
                                 type="number"
                                 @focus="updateFocus"
-                                @change="onDateChange('from', $event, filter)"
                                 @keyup="onDateChange('from', $event, filter)"
                             />
                             <input
@@ -64,7 +63,6 @@
                                 :value="dateFilterTo"
                                 type="number"
                                 @focus="updateFocus"
-                                @change="onDateChange('to', $event, filter)"
                                 @keyup="onDateChange('to', $event, filter)"
                             />
                         </div>
@@ -130,6 +128,7 @@ import FilterComponent from '@/components/Filter.vue';
 import ListPicker from '@/components/ListPicker.vue';
 import { Filter } from '@/models/Filter';
 import { directive } from 'vue3-click-away';
+import FilterHelperService from '@/services/filter-helper.service';
 
 const FOCUS_TIMEOUT_MS = 4000; // four seconds
 
@@ -326,7 +325,7 @@ export default defineComponent({
             this.showOnEdit = { status: false, filterType: 'none' };
 
             // if filter is really empty, i.e. user didn't enter any values, then we should not display it
-            if (this.currentFilter.value === '') {
+            if (!FilterHelperService.isValid(this.currentFilter)) {
                 this.$emit('removeFilter', this.currentFilter.id);
             }
             // Set the current filter to null, it's no longer current
@@ -346,6 +345,12 @@ export default defineComponent({
 
             this.onUpdateFilter('value', newCodes.join(','), filter.id); // Join new list together with commas and update the value
             this.updateFocus(); // Update focus so the user doesn't just randomly get knocked out of edit mode
+        },
+        /**
+         *  Checks whether filter meets all conditions to be displayed to user
+         */
+        eligible(filter: Filter, filterType: string): boolean {
+            return FilterHelperService.showFilter(filter, filterType);
         },
     },
 });

--- a/client/src/components/Filters.vue
+++ b/client/src/components/Filters.vue
@@ -9,7 +9,8 @@
                 v-on:delete="onRemoveClicked(filter.id)"
             />
         </div>
-        <div v-if="filter.type === 'language' && (filter.value !== '' || filter.isSelectionOpen)">
+        <div v-if="filter.type === 'language' && filter.value !== ''">
+            <!--    add isSelectionOpen if that behavior is more intuitive for disselect-->
             <FilterComponent
                 name="language"
                 :value="displayValue(languageList, filter.value)"

--- a/client/src/components/Filters.vue
+++ b/client/src/components/Filters.vue
@@ -370,7 +370,6 @@ export default defineComponent({
     box-shadow: 0 0 10px grey;
     box-sizing: border-box;
     padding: 10px 5px;
-    max-width: 120px;
     position: relative;
     z-index: 2000;
 }
@@ -381,16 +380,17 @@ export default defineComponent({
 }
 .year-selector > * > * {
     width: 90%;
-    margin: 5px;
 }
 .year-selector > * > label {
     text-align: left;
+    margin: 3px;
 }
 .year-selector > * > input {
     border-radius: 5px;
     background: lightgrey;
     border: none;
     padding: 0 5px;
+    margin: 5px;
 }
 
 .filter-container {

--- a/client/src/components/Filters.vue
+++ b/client/src/components/Filters.vue
@@ -300,6 +300,11 @@ export default defineComponent({
             } // If there isn't a currently focused element then forget about it
             // Emit update that changes isSelectionOpen (edit mode) to false
             this.$emit('updateFilter', { prop: 'isSelectionOpen', value: false, id: this.currentFilter.id });
+
+            // if filter is really empty, i.e. user didn't enter any values, then we should not display it
+            if (this.currentFilter.value === '') {
+                this.$emit('removeFilter', this.currentFilter.id);
+            }
             console.log('filters page, lostFocus.emit to close selection is sent.');
             // Set the current filter to null, it's no longer current
             this.currentFilter = null;

--- a/client/src/components/OptionsMenu.vue
+++ b/client/src/components/OptionsMenu.vue
@@ -148,10 +148,9 @@ export default defineComponent({
 .nodes-toggle-container {
     height: 41px;
     display: flex;
-    flex-direction: column;
-    justify-content: space-evenly;
-    align-items: flex-end;
-    margin-right: 10px; //TODO: check if this is still relevant
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
     padding: 15px;
     cursor: pointer;
 }
@@ -170,14 +169,6 @@ export default defineComponent({
 .nodes-toggle {
     display: flex;
     width: 50%;
-    justify-content: center;
-}
-
-#fixed-switch {
-    width: 22px;
-    height: 22px;
-    background-color: $brown;
-    border-radius: 90px;
-    box-shadow: 1px 1px 2px grey;
+    justify-content: flex-end;
 }
 </style>

--- a/client/src/components/OptionsMenu.vue
+++ b/client/src/components/OptionsMenu.vue
@@ -9,12 +9,7 @@
     />
 
     <!--  This div the menu container with nodes, togglers, and filters  -->
-    <div
-        class="main-container box-shadow card no-select"
-        v-show="openMenu === true"
-        @mouseleave="timeOut()"
-        @mouseenter="resetTimer()"
-    >
+    <div class="main-container box-shadow card no-select" v-show="openMenu === true" @mouseenter="resetTimer()">
         <!--  This is where the nodes can be activated and deactivated using togglers  -->
         <h4 class="labels">Selected data</h4>
         <div class="nodes-container">
@@ -50,7 +45,7 @@
             </div>
         </div>
 
-        <!--  TODO: This is where filters for narrowing down the results will be placed  -->
+        <!--  Filters  -->
         <h4 class="labels">Filters</h4>
         <div class="filters-container">
             <Filters
@@ -170,6 +165,8 @@ export default defineComponent({
 }
 
 .labels {
+    padding-top: 3px;
+    padding-left: 5px;
     text-align: start;
 }
 .nodes-labels {
@@ -182,7 +179,8 @@ export default defineComponent({
     display: flex;
     flex-direction: column;
     justify-content: space-evenly;
-    align-items: center;
+    align-items: flex-end;
+    margin-right: 10px;
 }
 p {
     margin: 16px 0;

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -11,6 +11,7 @@ import ToastService from 'primevue/toastservice';
 import SpeedDial from 'primevue/speeddial';
 import Tooltip from 'primevue/tooltip';
 import Skeleton from 'primevue/skeleton';
+import VueClickAway from 'vue3-click-away';
 
 // creating app
 const app = createApp(App).use(store).use(router);
@@ -18,6 +19,7 @@ const app = createApp(App).use(store).use(router);
 // add prime vue
 app.use(PrimeVue);
 app.use(ToastService, Toast);
+app.use(VueClickAway);
 app.component('ProgressBar', ProgressBar);
 app.component('Dialog', Dialog);
 app.component('SpeedDial', SpeedDial);

--- a/client/src/services/filter-helper.service.ts
+++ b/client/src/services/filter-helper.service.ts
@@ -26,4 +26,11 @@ export default class FilterHelperService {
             .map((filter) => `${filter.type}=${filter.value}`); // Convert to key=value strings
         return filterParams;
     }
+
+    /**
+     *  Only filters that are added to store and are being edited are to be shown. If not being edited, filter values should not be empty.
+     */
+    static showFilter(filter: Filter, currentType: string): boolean {
+        return filter.type === currentType && (filter.value !== '' || filter.isSelectionOpen);
+    }
 }

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -82,7 +82,7 @@ export default createStore({
         addFilter(state) {
             // Get the maxId and add one
             const newId = state.filters.reduce((a, b) => Math.max(a, b.id), -1) + 1;
-            state.filters = [...state.filters, { id: newId, type: 'empty', value: '' } as Filter];
+            state.filters = [...state.filters, { id: newId, type: 'empty', value: '' } as Filter]; //empty on first click
         },
 
         /**
@@ -97,9 +97,11 @@ export default createStore({
          */
         updateFilter<K extends keyof Filter>(state: AppState, args: { prop: K; value: Filter[K]; id: number }) {
             const startEdit = args.prop === 'isSelectionOpen';
+            console.log('store, updateFilter.selectionOpen status: ', startEdit);
             state.filters = state.filters
                 .filter((t) => !startEdit || t.type !== 'empty') // If we're starting to edit one, delete all empties
                 .map((filter: Filter) => {
+                    console.log('store, updateFilter.filtered: ', state.filters);
                     // If this is not the one that is being updated
                     if (args.id !== filter.id) {
                         // Don't allow for the opening of more than one at a time - close if open
@@ -107,11 +109,12 @@ export default createStore({
                     }
                     return {
                         ...filter, // Extend the current filter
-                        value: args.prop === 'type' ? '' : filter.value, // Clear the value if we are asigning /changing type
+                        value: args.prop === 'type' ? '' : filter.value, // Clear the value if we are assigning /changing type
                         isSelectionOpen: args.prop === 'type' || filter.isSelectionOpen, // If we just selected a type, we should show value selection
                         [args.prop]: args.value, // Set value
                     };
                 });
+            console.log('store, updateFilter.end result: ', state.filters);
         },
 
         /**

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -97,11 +97,9 @@ export default createStore({
          */
         updateFilter<K extends keyof Filter>(state: AppState, args: { prop: K; value: Filter[K]; id: number }) {
             const startEdit = args.prop === 'isSelectionOpen';
-            console.log('store, updateFilter.selectionOpen status: ', startEdit);
             state.filters = state.filters
                 .filter((t) => !startEdit || t.type !== 'empty') // If we're starting to edit one, delete all empties
                 .map((filter: Filter) => {
-                    console.log('store, updateFilter.filtered: ', state.filters);
                     // If this is not the one that is being updated
                     if (args.id !== filter.id) {
                         // Don't allow for the opening of more than one at a time - close if open
@@ -120,7 +118,6 @@ export default createStore({
                         [args.prop]: value, // Set value
                     };
                 });
-            console.log('store, updateFilter.end result: ', state.filters);
         },
 
         /**

--- a/client/src/styles/global.scss
+++ b/client/src/styles/global.scss
@@ -36,6 +36,13 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+    -ms-overflow-style: none;  /* hide scrollbar on IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+}
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+*::-webkit-scrollbar {
+    display: none;
 }
 
 // sets font family

--- a/client/src/views/Results.vue
+++ b/client/src/views/Results.vue
@@ -84,7 +84,6 @@ import Searchbar from '@/components/Searchbar.vue';
 import PatentPreview from '@/components/PatentPreview.vue';
 import KeywordSuggestions from '@/components/KeywordSuggestions.vue';
 import KeywordService from '@/services/keyword.service';
-import RoundButton from '@/components/RoundButton.vue';
 import OptionsMenu from '@/components/OptionsMenu.vue';
 import ResultsVisualization from '@/components/ResultVisualization.vue';
 import Button from '@/components/Button.vue';
@@ -120,17 +119,21 @@ export default defineComponent({
     watch: {
         filters(filters: Filter[]): void {
             // On every change of the filters we need to check if we should update the results
-            // Creata a filter string that we can compare to recently sent ones (this could be refactored)
+            // Create a filter string that we can compare to recently sent ones (this could be refactored)
+
             const newFilterString = filters
-                .filter((filter) => filter.type !== 'empty' && filter.value) // Remove empty or malformed filters
+                .filter((filter) => filter.type !== 'empty' && filter.value) // Remove empty or malformed filters TODO: check if works
                 .map((filter) => `${filter.type}=${filter.value}`)
                 .join('&'); // Convert to "key=value&key2=value2" string
 
+            console.log('results page, watch. new filter val: ', newFilterString);
+
             // Compare the string with the last sent, if they're different, refresh the results
             if (newFilterString !== this.lastFilterString) {
-                this.lastFilterString = newFilterString; // Update the last observered filter string for next time
+                this.lastFilterString = newFilterString; // Update the last observed filter string for next time
                 this.debounce(4000); // Refresh the results after 3 seconds
             }
+            console.log('results .... last filter val: ', this.lastFilterString);
         },
     },
     /**

--- a/client/src/views/Results.vue
+++ b/client/src/views/Results.vue
@@ -123,14 +123,11 @@ export default defineComponent({
             // Create a filter string that we can compare to recently sent ones (this could be refactored)
             const newFilterString = FilterHelperService.getParameterList(filters).join('&'); // Convert to "key=value&key2=value2" string
 
-            console.log('results page, watch. new filter val: ', newFilterString);
-
             // Compare the string with the last sent, if they're different, refresh the results
             if (newFilterString !== this.lastFilterString) {
                 this.lastFilterString = newFilterString; // Update the last observed filter string for next time
                 this.debounce(4000); // Refresh the results after 3 seconds
             }
-            console.log('results .... last filter val: ', this.lastFilterString);
         },
     },
     /**


### PR DESCRIPTION
- clickaway closes open filter chips or list picker
- filter removed if empty after update (_note_: filter is added on chip click by design)
- filter shown (red) during edit
- selected terms left-aligned
- add button aligned with filters

also includes changes authored by @samuelhuebner in `fix/filter-item-alignments`