### PR TITLE
Add fade effect to loaded results when loading

### DIFF
--- a/client/src/components/PatentPreview.vue
+++ b/client/src/components/PatentPreview.vue
@@ -14,8 +14,7 @@
                 <RoundButton class="round-btn" icon-key="more_horiz" @click="settingsMenu = !settingsMenu" />
             </div>
             <div class="settings-menu" v-if="settingsMenu">
-
-                <RoundButton v-if="!isSaved" class="round-btn" icon-key="bookmark" @click="this.savePatent" />         
+                <RoundButton v-if="!isSaved" class="round-btn" icon-key="bookmark" @click="this.savePatent" />
                 <RoundButton class="round-btn" icon-key="visibility_off" @click="this.hidePatent" />
                 <RoundButton class="round-btn" icon-key="done" />
                 <RoundButton class="round-btn" icon-key="read_more" @click="this.showMore" />

--- a/client/src/components/ResultVisualization.vue
+++ b/client/src/components/ResultVisualization.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="d3-container">
+    <div :class="{ 'd3-container': true, updating: updating }">
         <svg xmlns="http://www.w3.org/2000/svg" @click="canvasClicked">
             <defs>
                 <marker
@@ -89,6 +89,7 @@ export default defineComponent({
             required: true,
             type: Array,
         },
+        updating: Boolean,
     },
     emits: {
         onNodeSelected: (e: { node: NodeInfo }) => e,
@@ -717,6 +718,11 @@ export default defineComponent({
         height: 100%;
         width: 100%;
     }
+}
+.d3-container.updating {
+    transition: all 0.5s;
+    z-index: -1;
+    opacity: 0.5;
 }
 
 .tooltip {

--- a/client/src/services/patent.service.ts
+++ b/client/src/services/patent.service.ts
@@ -32,7 +32,6 @@ export default class PatentService extends HttpService {
         // reset requestPending variable
         this.requestPending = false;
 
-
         //temporary approach to handle no results meeting filters
         if (json.length === 0) {
             PatentService.throwError(404);

--- a/client/src/views/Results.vue
+++ b/client/src/views/Results.vue
@@ -34,6 +34,7 @@
             <ResultsVisualization
                 :visualization-options="visualizationOptions"
                 :patents="patents"
+                :updating="showLoadingBar"
                 v-on:on-node-selected="onNodeSelected"
                 v-on:on-clear-node-selected="onClearNodeSelected"
             />
@@ -150,6 +151,9 @@ export default defineComponent({
      * and patents from store/index.ts
      */
     computed: {
+        showLoadingBar(): boolean {
+            return this.$store.state.showLoadingBar;
+        },
         filters(): Filter[] {
             return this.$store.state.filters;
         },


### PR DESCRIPTION
This PR is very optional. When trying (unsuccessfully) to reproduce PST-147 I realized that perhaps this would look nice so I did it. 

When the loading bar is shown (changing the terms / filters, or loading more) this PR makes the results partially transparent until the loading is done.

Let me know if we should merge it or throw it out!

