### PR TITLE
refactor(client): Changed not-found toast - PST-161

### DIFF
--- a/client/src/components/Toasts.vue
+++ b/client/src/components/Toasts.vue
@@ -20,9 +20,9 @@ export default defineComponent({
         const showNoPatentsToast = () => {
             toast.add({
                 severity: 'warn',
-                summary: "'Oops! No result found :('",
-                detail: 'Please modify your search criteria and you will find results matching your needs',
-                life: 10000,
+                summary: 'Oops! No result found :)',
+                detail: 'Try modifying your filters or search terms',
+                life: 5000,
             });
         };
         const showErrorToast = () => {

--- a/client/src/components/Toasts.vue
+++ b/client/src/components/Toasts.vue
@@ -18,7 +18,12 @@ export default defineComponent({
     setup() {
         const toast = useToast();
         const showNoPatentsToast = () => {
-            toast.add({ severity: 'error', summary: 'Error', detail: 'No results found', life: 3000 });
+            toast.add({
+                severity: 'warn',
+                summary: "'Oops! No result found :('",
+                detail: 'Please modify your search criteria and you will find results matching your needs',
+                life: 10000,
+            });
         };
         const showErrorToast = () => {
             toast.add({ severity: 'error', summary: 'Error', detail: 'Error occurred', life: 3000 });


### PR DESCRIPTION
…the result page - PST-161
In the last meeting with the customer, he pointed out that the error message should be replaced with some info message about result not found. 
I came with two options: 
1. warning toast
2. info toast
Please tell me your opinion and impression. 
![image](https://user-images.githubusercontent.com/34209362/141170271-6c4dc0e8-850b-4541-95e8-370f363c0815.png)
