### PR TITLE
 Node highlight and marking restored - PST-160

### DIFF
--- a/client/src/store/AppState.ts
+++ b/client/src/store/AppState.ts
@@ -56,7 +56,10 @@ export class AppState extends SavedAppState {
      * Id of patent currently previewed (on Results page)
      */
     public patentID = '' as string;
-
+    /**
+     * Type of node currently highlighted
+     */
+    public patentType = '' as string;
     /**
      * Highlight border of a node upon its click or preview
      */

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -244,15 +244,13 @@ export default createStore({
         /**
          * Switches highlight for node on. Each node is saved for later checkmark restoration.
          * @param state
-         * @param pID - ID of patent being previewed
+         * @param obj - contains ID and type of node to be highlighted
          */
-        HIGHLIGHT_NODE_ON(state, pID: string) {
-            if (pID === null || pID.length < 0 || pID === 'undefined') {
-                return;
-            }
+        HIGHLIGHT_NODE_ON(state, obj: { pID: string; nodeType: string }) {
+            if (obj.pID === null || obj.pID.length < 0 || obj.pID === 'undefined') return;
 
-            state.patentID = pID;
-
+            state.patentID = obj.pID;
+            state.patentType = obj.nodeType;
             state.highlightNode = true;
         },
         /**
@@ -261,20 +259,23 @@ export default createStore({
          */
         HIGHLIGHT_NODE_OFF(state) {
             state.patentID = '';
+            state.patentType = '';
             state.highlightNode = false;
         },
-        MARK_NODE_ON(state, obj: { pID: string; twice: boolean }) {
-            if (obj.pID === null || obj.pID.length < 0 || obj.pID === 'undefined') {
-                return;
-            }
+        /**
+         * Adds checkmarks to the visited patent
+         *
+         */
+        ADD_MARK(state, obj: { pID: string; twice: boolean }) {
+            if (obj.pID === null || obj.pID.length < 0 || obj.pID === 'undefined') return;
 
             state.patentID = obj.pID;
             state.markTwice = obj.twice; //if true mark twice
+            // if (state.markedTwice.indexOf(obj.pID) >= 0) return; //don't change the mark if already exists
             state.markTwice ? state.markedTwice.push(obj.pID) : state.markedOnce.push(obj.pID);
-
             //filter duplicates out
-            state.markedOnce = state.markedOnce.filter((e, i) => i === state.markedOnce.indexOf(e));
-            state.markedTwice = state.markedTwice.filter((e, i) => i === state.markedTwice.indexOf(e));
+            state.markedOnce = state.markedOnce.filter((e, i) => state.markedOnce.indexOf(e) === i);
+            state.markedTwice = state.markedTwice.filter((e, i) => state.markedTwice.indexOf(e) === i);
 
             // remove matching ids from markedOnce
             state.markedOnce = state.markedOnce.filter((e) => state.markedTwice.indexOf(e) < 0);

--- a/client/src/views/Results.vue
+++ b/client/src/views/Results.vue
@@ -38,9 +38,14 @@
                 v-on:on-clear-node-selected="onClearNodeSelected"
             />
         </div>
-        <!-- This div contains the bottom controls (timeline toggle, mode-toggle)     v-if="moreDataAvailable" -->
+        <!-- This div contains the bottom controls (timeline toggle, mode-toggle) -->
         <div class="bottom-controls">
-            <Button v-on:on-clicked="extendSearch" icon-key="check" btn-text="Load more"></Button>
+            <Button
+                v-if="moreDataAvailable"
+                v-on:on-clicked="extendSearch"
+                icon-key="check"
+                btn-text="Load more"
+            ></Button>
         </div>
         <!-- This div contains the top right controls (saved button) -->
         <div class="top-controls">

--- a/client/src/views/SavedResult.vue
+++ b/client/src/views/SavedResult.vue
@@ -113,10 +113,10 @@ export default defineComponent({
             this.selectedPatent = patent;
             this.$store.commit('SHOW_DIALOG_MASK');
             //set mark twice on viewed node
-            this.$store.commit('MARK_NODE_ON', { pID: patent.patent.id, twice: true });
+            this.$store.commit('ADD_MARK', { pID: patent.patent.id, twice: true });
             //set mark twice on viewed node
             setTimeout(() => {
-                this.$store.commit('HIGHLIGHT_NODE_ON', patent.patent.id);
+                this.$store.commit('HIGHLIGHT_NODE_ON', { pID: patent.patent.id, nodeType: 'patent' });
             });
         },
     },


### PR DESCRIPTION
nodes should be highlighted correctly again. 

if patent -> receives a mark, else only highlighted

NOTE: @duaakelzi I disabled your load-more button check because the load-more button would not be shown at all for me otherwise. I think I'm on the latest version of main