### PR TITLE
Fix empty author/company maps causing error - PST-162

### DIFF
--- a/client/src/components/PatentPreview.vue
+++ b/client/src/components/PatentPreview.vue
@@ -14,7 +14,7 @@
                 <RoundButton class="round-btn" icon-key="more_horiz" @click="settingsMenu = !settingsMenu" />
             </div>
             <div class="settings-menu" v-if="settingsMenu">
-                <RoundButton v-if="!isSaved" class="round-btn" icon-key="bookmark" @click="this.savePatent" />
+                <RoundButton v-if="current.showSave" class="round-btn" icon-key="bookmark" @click="this.savePatent" />
                 <RoundButton class="round-btn" icon-key="visibility_off" @click="this.hidePatent" />
                 <RoundButton class="round-btn" icon-key="done" />
                 <RoundButton class="round-btn" icon-key="read_more" @click="this.showMore" />

--- a/client/src/services/visualization-helper.service.ts
+++ b/client/src/services/visualization-helper.service.ts
@@ -229,8 +229,8 @@ export default class VisualizationHelperService {
             .reduce(
                 (stakeholders, patent) => [
                     ...stakeholders,
-                    ...(patent[path] || []).map((inventor: string) => ({
-                        source: inventor,
+                    ...(patent[path] || []).map((id: string) => ({
+                        source: id,
                         target: patent.id,
                     })),
                 ],
@@ -267,7 +267,7 @@ export default class VisualizationHelperService {
             .reduce(
                 (links, node) => [
                     ...links,
-                    ...relationMap[node.id].map((t) => ({
+                    ...(relationMap[node.id] || []).map((t) => ({
                         source: node,
                         target: nodeMap[t],
                     })),


### PR DESCRIPTION
Actually two bugs rolled into this one
1) When loading the page with both authors and companies on, then toggling one off the page would throw an error
2) I accidentally broke hiding save button when a patent is saved, so this fixes it

I can pull them into two PRs if required.