### PR TITLE
fix(server): Fix load more button not appearing - PST-164

### DIFF
--- a/server/src/patents/patents.service.helper.ts
+++ b/server/src/patents/patents.service.helper.ts
@@ -19,6 +19,7 @@ export class PatentsServiceHelper {
      */
     public static processQuery(data: PatentQueryResponse, languages?: string): QueryResult {
         const searchResult = data['ops:world-patent-data']['ops:biblio-search'];
+        const totalCount = data['ops:world-patent-data']['ops:biblio-search']['@total-result-count'];
 
         let queryData = searchResult['ops:search-result']['exchange-documents'];
         if (!(queryData instanceof Array)) {
@@ -49,7 +50,7 @@ export class PatentsServiceHelper {
 
         return {
             patents: processed,
-            total: processed.length,
+            total: Number(totalCount),
         };
     }
 


### PR DESCRIPTION
This was caused by an change I introduced for the family query without thinking about the consequences of this change. 

The load more button should now appear again