### PR TITLE
fix(client): Fix footer not showing up in production - PST-194

### DIFF
--- a/client/src/views/Search.vue
+++ b/client/src/views/Search.vue
@@ -43,12 +43,6 @@ export default defineComponent({
     created(): void {
         this.$store.commit('HIDE_LOADING_BAR');
         this.$store.dispatch('resetSavedState');
-
-        // adds the loading screen for 0.5s
-        this.$store.commit('SHOW_LOADING_SCREEN');
-        setTimeout(() => {
-            this.$store.commit('HIDE_LOADING_SCREEN');
-        }, 800);
     },
     computed: {
         searchTerms(): string[] {
@@ -160,15 +154,8 @@ export default defineComponent({
     color: unset;
 }
 
-.gh-logo,
-.separator,
-.about-link {
-    opacity: 50%;
-}
-
 .gh-logo:hover,
 .about-link:hover {
-    opacity: 100%;
     transition: all 1s ease;
     cursor: pointer;
 }


### PR DESCRIPTION
Currently the bottom-section is not visible in production for some odd reason:
![image](https://user-images.githubusercontent.com/36863168/142056325-573e41ca-8436-4dea-8e0d-9b1374d9ae9d.png)

Tried the "fix" out by deploying it manually to the hosted version and the section seems to show up now